### PR TITLE
Fix: Resolve runtime error by adding network entitlement for macOS

### DIFF
--- a/Extension Downloader/Extension_Downloader.entitlements
+++ b/Extension Downloader/Extension_Downloader.entitlements
@@ -4,6 +4,8 @@
 <dict>
 	<key>com.apple.security.app-sandbox</key>
 	<true/>
+	<key>com.apple.security.network.client</key>
+	<true/>
 	<key>com.apple.security.files.user-selected.read-only</key>
 	<true/>
 </dict>


### PR DESCRIPTION
This commit addresses a runtime error in the macOS VSIX Downloader application that likely occurred when trying to download extension files.

The primary change is the addition of the `com.apple.security.network.client` key to the `Extension Downloader/Extension_Downloader.entitlements` file. This entitlement is required for sandboxed macOS applications to perform outgoing network operations, such as downloading files using `URLSession`.

Additionally, an investigation confirmed that the application's download functionality relies on the native Swift implementation (`VSIXDownloader.swift`) and does not actively use the Python script (`ED.py`) found in the repository.

Recommended follow-up:
- You may want to remove the unused `Extension Downloader/ED.py` script and potentially related files to clean up the project and avoid confusion.
- I recommend you conduct thorough testing of the download functionality on a macOS environment to confirm the resolution of the runtime error, as I was unable to execute tests in the current environment.